### PR TITLE
Workaround issue where we sometimes allow changes that broke existing…

### DIFF
--- a/descriptor-model/src/main/java/com/spotify/protoman/descriptor/DescriptorBuilder.java
+++ b/descriptor-model/src/main/java/com/spotify/protoman/descriptor/DescriptorBuilder.java
@@ -1,6 +1,7 @@
 package com.spotify.protoman.descriptor;
 
 import com.google.auto.value.AutoValue;
+import com.google.protobuf.DescriptorProtos;
 import java.nio.file.Path;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -26,13 +27,13 @@ public interface DescriptorBuilder extends AutoCloseable {
   @AutoValue
   abstract class Result {
 
-    @Nullable public abstract DescriptorSet descriptorSet();
+    @Nullable public abstract DescriptorProtos.FileDescriptorSet fileDescriptorSet();
 
     // TODO(staffan): Change this into a collection of more structured types?
     @Nullable public abstract String compilationError();
 
-    public static Result create(final DescriptorSet descriptorSet) {
-      return new AutoValue_DescriptorBuilder_Result(descriptorSet, null);
+    public static Result create(final DescriptorProtos.FileDescriptorSet fileDescriptorSet) {
+      return new AutoValue_DescriptorBuilder_Result(fileDescriptorSet, null);
     }
 
     public static Result error(final String compilationError) {

--- a/descriptor-model/src/main/java/com/spotify/protoman/descriptor/ProtocDescriptorBuilder.java
+++ b/descriptor-model/src/main/java/com/spotify/protoman/descriptor/ProtocDescriptorBuilder.java
@@ -61,7 +61,7 @@ public class ProtocDescriptorBuilder implements DescriptorBuilder {
   public Result buildDescriptor(final Stream<Path> paths) throws DescriptorBuilderException {
     final ImmutableList<Path> pathsList = paths.collect(toImmutableList());
     if (pathsList.isEmpty()) {
-      return Result.create(DescriptorSet.empty());
+      return Result.create(DescriptorProtos.FileDescriptorSet.getDefaultInstance());
     }
 
     try {
@@ -96,8 +96,7 @@ public class ProtocDescriptorBuilder implements DescriptorBuilder {
         try (final InputStream is = Files.newInputStream(descriptorFilePath)) {
           final DescriptorProtos.FileDescriptorSet fileDescriptorSet =
               DescriptorProtos.FileDescriptorSet.parseFrom(is);
-
-          return Result.create(DescriptorSet.create(fileDescriptorSet, paths::contains));
+          return Result.create(fileDescriptorSet);
         }
       } else {
         return Result.error(CharStreams.toString(new InputStreamReader(process.getErrorStream())));

--- a/descriptor-model/src/test/java/com/spotify/protoman/descriptor/ProtocDescriptorBuilderTest.java
+++ b/descriptor-model/src/test/java/com/spotify/protoman/descriptor/ProtocDescriptorBuilderTest.java
@@ -4,6 +4,7 @@ import static com.spotify.hamcrest.optional.OptionalMatchers.optionalWithValue;
 import static com.spotify.hamcrest.pojo.IsPojo.pojo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -39,10 +40,7 @@ public class ProtocDescriptorBuilderTest {
         is(nullValue())
     );
 
-    assertThat(
-        result.descriptorSet().fileDescriptors(),
-        hasSize(2)
-    );
+    assertThat(result.fileDescriptorSet().getFileList(), hasSize(2));
   }
 
   @Test
@@ -63,20 +61,7 @@ public class ProtocDescriptorBuilderTest {
 
     final DescriptorBuilder.Result result = sut.buildDescriptor(Stream.of(path1));
 
-    assertThat(
-        result.descriptorSet().fileDescriptors(),
-        hasSize(1)
-    );
-
-    assertThat(
-        result.descriptorSet().findFileByPath(path1)
-            .get()
-            .findMessageByName("One")
-            .findFieldByName("two")
-            .messageType()
-            .name(),
-        equalTo("Two")
-    );
+    assertThat(result.fileDescriptorSet().getFileList(), hasSize(2));
   }
 
   @Test
@@ -96,8 +81,9 @@ public class ProtocDescriptorBuilderTest {
     );
 
     final DescriptorBuilder.Result result = sut.buildDescriptor(Stream.of(path));
+    final DescriptorSet ds = DescriptorSet.create(result.fileDescriptorSet(), __ -> true);
     final MessageDescriptor typeDescriptor =
-        result.descriptorSet().findFileByPath(path).get().findMessageByName("MyCoolType");
+        ds.findFileByPath(path).get().findMessageByName("MyCoolType");
     assertThat(
         typeDescriptor.sourceCodeInfo(),
         optionalWithValue(
@@ -120,10 +106,7 @@ public class ProtocDescriptorBuilderTest {
 
     final DescriptorBuilder.Result result = sut.buildDescriptor(Stream.of(path));
 
-    assertThat(
-        result.descriptorSet().fileDescriptors(),
-        hasSize(1)
-    );
+    assertThat(result.fileDescriptorSet().getFileList(), hasSize(1));
   }
 
   @Test
@@ -135,10 +118,7 @@ public class ProtocDescriptorBuilderTest {
     sut.setProtoFile(Paths.get("foo/bar/qux.proto"), "syntax = 'proto3';");
 
     final DescriptorBuilder.Result result = sut.buildDescriptor(Stream.empty());
-    assertThat(
-        result.descriptorSet().fileDescriptors(),
-        hasSize(0)
-    );
+    assertThat(result.fileDescriptorSet().getFileList(), is(empty()));
   }
 
   @Test

--- a/testutil/src/main/java/com/spotify/protoman/testutil/DescriptorSetUtils.java
+++ b/testutil/src/main/java/com/spotify/protoman/testutil/DescriptorSetUtils.java
@@ -46,8 +46,8 @@ public class DescriptorSetUtils {
       if (result.compilationError() != null) {
         throw new RuntimeException("Protobuf compilation failed: " + result.compilationError());
       }
-      checkNotNull(result.descriptorSet());
-      return result.descriptorSet();
+      checkNotNull(result.fileDescriptorSet());
+      return DescriptorSet.create(result.fileDescriptorSet(), __ -> true);
     }
   }
 
@@ -93,7 +93,7 @@ public class DescriptorSetUtils {
         throw new RuntimeException("Failed to build descriptor set: " + result.compilationError());
       }
 
-      return result.descriptorSet();
+      return DescriptorSet.create(result.fileDescriptorSet(), filter);
     }
   }
 


### PR DESCRIPTION
… protos

Consider the case where the following files exists in the repository:

```
herp/derp.proto:
  package herp;
  message Derp {}
foo/bar.proto
  package foo;
  import "herp/derp.proto"
  message Bar {
    Derp derp = 1;
  }
```

And a publish request that changes `herp/derp.proto' to:

```
package herp;
message Herpaderp {} // Derp was removed/renamed!
```

That change will break `foo/bar.proto` -- BUT protoc will succeeded if we
only run it with `foo/bar.proto` as the input.

So, we either need to either:
- Run protoc will ALL files as input, or
- Run protoc will ALL files that DEPEND ON a file being changed as input, or
- Track dependencies are ensured that types in use are not removed

This change takes the first approach to solve the issue. Which isn't ideal,
but was the quickest fix.

To make that change this commit includes changes to refactor DescriptorBuilder
to return `FileDescriptorSet` protos instead of `DescriptorSet`.