### PR TITLE
Fix bug where validation would fail unless you publish ALL files ...

### DIFF
--- a/registry/src/main/java/com/spotify/protoman/registry/SchemaRegistry.java
+++ b/registry/src/main/java/com/spotify/protoman/registry/SchemaRegistry.java
@@ -184,7 +184,7 @@ public class SchemaRegistry implements SchemaPublisher, SchemaGetter {
    * includedPaths} only contains a.proto then the resulting {@link DescriptorSet} will only
    * contain a.proto.
    */
-  private static  @Nullable DescriptorSet createFilteredDescriptorSet(
+  private static @Nullable DescriptorSet createFilteredDescriptorSet(
       @Nullable final DescriptorProtos.FileDescriptorSet fileDescriptorSet,
       final ImmutableSet<Path> includedPaths) {
     return fileDescriptorSet != null


### PR DESCRIPTION
... currently in the registry.

The bug was that we compared a descriptor set for all files (current)
to a descriptor set filtered to only contain descriptors for the files
modified (candidate).

This meant we got a lot of false positives of things being removed.